### PR TITLE
Modified Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 <br><br>
 <div align="center">
-    <img src="assets/img/logo/readme/logo-white-cropped.png" alt="Antaeus Logo" width="15%" style="margin-bottom: -50px;">
+    <img src="assets/img/logo/readme/logo-white-cropped.png" alt="Antaeus Logo" width="15%" style="margin-bottom: -10px;">
 </div>
-<h1 align="center" style="margin-top: -50px;">Ἀνταῖος</h1>
+<h1 align="center" style="margin-top: -10px;">Ἀνταῖος</h1>
 
 Antaeus is a versatile framework based on [Vexide](https://vexide.dev)
 that aims to be powerful for experts while still being easy to use for beginners.
+
+# An official project by members of:
+<p align="center">
+  <img src="https://8059blank.github.io/images/8059blank-crop.png" width="50%" />
+</p>
+
 
 # Philosophy
 
@@ -16,12 +22,12 @@ robots. This framework/library is designed to be easy and faster to implement.
 
 ## Comparison with Evian
 
-[Evian](https://github.com/vexide/evian) is a complete framework based on Vexide
-as well that Antaeus was inspired by. It aims to be a extensible framework that
+[Evian](https://github.com/vexide/evian) is a complete framework based on [Vexide](https://vexide.dev)
+as well what Antaeus was inspired by. It aims to be a extensible framework that
 is easy to use as well. However, Antaeus aims to be less extensible and more of
 an all-rounded framework, not only for autonomous motion but for advanced
-driver control operations. It is important that you carefully pick which library
-you would like to use before continuing.
+driver control operations. To ensure the best results, please carefully select
+the library you plan to use before continuing.
 
 ## A Notice before using Antaeus
 
@@ -33,9 +39,26 @@ without thinking much. If you have new ideas, you are really really encouraged
 to contribute to this library and/or create your own library. More on
 contribution can be found in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
+# Made possible with:
+
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://vexide.dev">
+        <img src="https://vexide.dev/images/logo_opengraph.png" width="128px;" alt="Vexide"/>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://www.rust-lang.org">
+        <img src="https://raw.githubusercontent.com/rust-lang/rust-artwork/master/logo/rust-logo-256x256-blk.png" width="128px;" alt="Rust"/>
+      </a>
+    </td>
+  </tr>
+</table>
+
 # License
 
-Copyright (C) 2025 Harshal (Saturnyx)
+Copyright (C) 2026 Harshal (Saturnyx) </br>
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, version 3.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
In ./README.md:
Changed copyright year 2025->2026.
Added images of Vexide , 8059Blank and Rust.
html wrapper of images, note that its linked to the official website`s logo and not in the official project folder as .png files.